### PR TITLE
Prevent fragments from crashing when no bundle provided

### DIFF
--- a/app/src/main/java/com/github/fo2rist/mclaren/ui/CircuitDetailsFragment.java
+++ b/app/src/main/java/com/github/fo2rist/mclaren/ui/CircuitDetailsFragment.java
@@ -15,6 +15,7 @@ import com.github.fo2rist.mclaren.R;
 import com.github.fo2rist.mclaren.ui.models.CalendarEvent;
 import com.github.fo2rist.mclaren.ui.widgets.InformationLineView;
 import com.github.fo2rist.mclaren.utils.IntentUtils;
+import timber.log.Timber;
 
 import static com.github.fo2rist.mclaren.utils.ResourcesUtils.getCircuitDetailedImageUriById;
 
@@ -23,6 +24,7 @@ public class CircuitDetailsFragment extends Fragment implements View.OnClickList
 
     private static final String ARG_EVENT = "event";
 
+    @Nullable
     private CalendarEvent event;
 
     @NonNull
@@ -41,19 +43,18 @@ public class CircuitDetailsFragment extends Fragment implements View.OnClickList
     @Override
     public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        fetchParameters(getArguments());
+        fetchBundleParameters();
     }
 
-    private void fetchParameters(Bundle bundle) {
-        if (bundle == null) {
-            throw new IllegalArgumentException("No arguments provided");
+    private void fetchBundleParameters() {
+        Bundle args = getArguments();
+        if (args == null) {
+            Timber.e("No arguments provided for fragment");
+            //TODO forward error-level logging to Crashlytics. 2018-02-25
+            return;
         }
 
-        event = (CalendarEvent) bundle.getSerializable(ARG_EVENT);
-
-        if (event == null) {
-            throw new IllegalArgumentException("No circuit provided to display");
-        }
+        event = (CalendarEvent) args.getSerializable(ARG_EVENT);
     }
 
     @Nullable
@@ -67,6 +68,11 @@ public class CircuitDetailsFragment extends Fragment implements View.OnClickList
     }
 
     private void populateView(View rootView) {
+        if (event == null) {
+            Timber.e("No circuit model provided to display");
+            return;
+        }
+
         ImageView circuitImageView = rootView.findViewById(R.id.circuit_image);
         circuitImageView.setImageURI(getCircuitDetailedImageUriById(event.circuitId));
 

--- a/app/src/main/java/com/github/fo2rist/mclaren/ui/CircuitsFragment.java
+++ b/app/src/main/java/com/github/fo2rist/mclaren/ui/CircuitsFragment.java
@@ -38,7 +38,9 @@ public class CircuitsFragment extends Fragment {
     }
 
     private static final String ARG_COLUMN_COUNT = "column-count";
-    private int columnCount = 2;
+    private static final int DEFAULT_COLUMNS_COUNT = 2;
+
+    private int columnCount = DEFAULT_COLUMNS_COUNT;
     private OnCircuitsFragmentInteractionListener listener;
 
     /**
@@ -59,9 +61,13 @@ public class CircuitsFragment extends Fragment {
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        fetchBundleParameters();
+    }
 
-        if (getArguments() != null) {
-            columnCount = getArguments().getInt(ARG_COLUMN_COUNT);
+    private void fetchBundleParameters() {
+        Bundle args = getArguments();
+        if (args != null) {
+            columnCount = args.getInt(ARG_COLUMN_COUNT, DEFAULT_COLUMNS_COUNT);
         }
     }
 

--- a/app/src/main/java/com/github/fo2rist/mclaren/ui/DriverSubFragment.java
+++ b/app/src/main/java/com/github/fo2rist/mclaren/ui/DriverSubFragment.java
@@ -71,9 +71,23 @@ public class DriverSubFragment extends Fragment implements View.OnClickListener 
     }
 
     @Override
+    public void onDetach() {
+        super.onDetach();
+        listener = null;
+    }
+
+    @Override
     public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        fetchBundleParameters();
+    }
+
+    private void fetchBundleParameters() {
         Bundle args = getArguments();
+        if (args == null) {
+            Timber.e("No arguments provided for fragment");
+            return;
+        }
         DriverId driverId = (DriverId) args.getSerializable(ARG_DRIVER);
         driver = DriversFactory.getDriverModel(driverId);
     }
@@ -89,13 +103,11 @@ public class DriverSubFragment extends Fragment implements View.OnClickListener 
         return rootView;
     }
 
-    @Override
-    public void onDetach() {
-        super.onDetach();
-        listener = null;
-    }
-
     private void populateViews(View rootView) {
+        if (driver == null) {
+            Timber.e("No driver model provided to display");
+            return;
+        }
         TextView titleTextView = rootView.findViewById(R.id.driver_number_text);
         titleTextView.setText(driver.getProperty(AdditionalProperty.TAG));
 

--- a/app/src/main/java/com/github/fo2rist/mclaren/ui/ImagePreviewFragment.java
+++ b/app/src/main/java/com/github/fo2rist/mclaren/ui/ImagePreviewFragment.java
@@ -17,6 +17,7 @@ import com.github.fo2rist.mclaren.ui.presenters.ImagePreviewPresenter;
 
 public class ImagePreviewFragment extends Fragment implements ImagePreviewContract.View {
     private static final String ARG_FEED_ITEM = "feed_item";
+
     private ImagePreviewContract.Presenter presenter;
     private ViewPager imagesPager;
 
@@ -32,17 +33,29 @@ public class ImagePreviewFragment extends Fragment implements ImagePreviewContra
     @Override
     public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container,
             @Nullable Bundle savedInstanceState) {
-        presenter = new ImagePreviewPresenter();
         View rootView = inflater.inflate(R.layout.fragment_image_preview, container, false);
-        Bundle arguments = getArguments();
-        if (arguments == null) {
-            return rootView;
-        }
-        FeedItem feedItem = (FeedItem) arguments.getSerializable(ARG_FEED_ITEM);
         imagesPager = rootView.findViewById(R.id.images_pager);
-
-        presenter.onStartWith(this, feedItem);
         return rootView;
+    }
+
+    @Override
+    public void onStart() {
+        super.onStart();
+
+        FeedItem feedItem = fetchBundleParameters();
+        if (feedItem != null) {
+            presenter = new ImagePreviewPresenter();
+            presenter.onStartWith(this, feedItem);
+        }
+    }
+
+    private FeedItem fetchBundleParameters() {
+        Bundle args = getArguments();
+        if (args == null) {
+            return null;
+        }
+
+        return (FeedItem) args.getSerializable(ARG_FEED_ITEM);
     }
 
     @Override

--- a/app/src/main/java/com/github/fo2rist/mclaren/ui/WebPreviewFragment.java
+++ b/app/src/main/java/com/github/fo2rist/mclaren/ui/WebPreviewFragment.java
@@ -23,6 +23,8 @@ public class WebPreviewFragment extends Fragment {
     private static final String ARG_URL = "url";
     private static final String ARG_MCLAREN_HTML = "mclaren_html";
 
+    private WebView webView;
+
     public static WebPreviewFragment newInstanceForUrl(String url) {
         return createInstanceWithArgs(ARG_URL, url);
     }
@@ -45,21 +47,24 @@ public class WebPreviewFragment extends Fragment {
     public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container,
             @Nullable Bundle savedInstanceState) {
         View rootView = inflater.inflate(R.layout.fragment_web_preview, container, false);
+        webView = rootView.findViewById(R.id.web_view);
+        setupWebView(webView);
+        return rootView;
+    }
+
+    @Override
+    public void onStart() {
+        super.onStart();
+
         Bundle arguments = getArguments();
         if (arguments == null) {
-            return rootView;
+            return;
         }
-
-        WebView webView = rootView.findViewById(R.id.web_view);
-        setupWebView(webView);
-
         if (arguments.containsKey(ARG_URL)) {
             loadUrl(webView, arguments.getString(ARG_URL));
         } else if (arguments.containsKey(ARG_MCLAREN_HTML)) {
             loadHtml(webView, arguments.getString(ARG_MCLAREN_HTML));
         }
-
-        return rootView;
     }
 
     @SuppressLint("SetJavaScriptEnabled")


### PR DESCRIPTION
Empty bundle can be delivered by some android devices on fragment re-creation