### PR TITLE
Fix crash after main screen restart

### DIFF
--- a/app/src/main/java/com/github/fo2rist/mclaren/mvp/BasePresenter.java
+++ b/app/src/main/java/com/github/fo2rist/mclaren/mvp/BasePresenter.java
@@ -2,8 +2,15 @@ package com.github.fo2rist.mclaren.mvp;
 
 import android.support.annotation.NonNull;
 
+/** Common interface for MVP presenters in the app to used keep start/stop consistent. */
 public interface BasePresenter<T extends BaseView> {
+    /**
+     * Should be called when the view starts and the interaction is possible.
+     */
     void onStart(@NonNull T view);
 
+    /**
+     * Should be called when the view is going to die for good and no more interaction expected.
+     */
     void onStop();
 }

--- a/app/src/main/java/com/github/fo2rist/mclaren/mvp/MainScreenContract.java
+++ b/app/src/main/java/com/github/fo2rist/mclaren/mvp/MainScreenContract.java
@@ -1,5 +1,7 @@
 package com.github.fo2rist.mclaren.mvp;
 
+import android.support.annotation.NonNull;
+
 public interface MainScreenContract {
 
     interface View extends BaseView {
@@ -16,6 +18,8 @@ public interface MainScreenContract {
     }
 
     interface Presenter extends BasePresenter<View> {
+        /** Should be called when activity re-created with state restored. */
+        void onRestart(@NonNull View view);
         void onStoriesClicked();
         void onCircuitsClicked();
         void onDriversClicked();

--- a/app/src/main/java/com/github/fo2rist/mclaren/ui/MainActivity.java
+++ b/app/src/main/java/com/github/fo2rist/mclaren/ui/MainActivity.java
@@ -76,6 +76,9 @@ public class MainActivity extends AppCompatActivity
         if (savedInstanceState == null) {
             //Populate main content area only on the first launch
             presenter.onStart(this);
+        } else {
+            //otherwise, just re-couple view and presenter.
+            presenter.onRestart(this);
         }
     }
 

--- a/app/src/main/java/com/github/fo2rist/mclaren/ui/MainPresenter.java
+++ b/app/src/main/java/com/github/fo2rist/mclaren/ui/MainPresenter.java
@@ -1,5 +1,7 @@
 package com.github.fo2rist.mclaren.ui;
 
+import android.support.annotation.NonNull;
+
 import com.github.fo2rist.mclaren.analytics.Events;
 import com.github.fo2rist.mclaren.analytics.EventsLogger;
 import com.github.fo2rist.mclaren.mvp.MainScreenContract;
@@ -22,12 +24,17 @@ public class MainPresenter implements MainScreenContract.Presenter {
     }
 
     @Override
-    public void onStart(MainScreenContract.View view) {
+    public void onStart(@NonNull MainScreenContract.View view) {
         this.view = view;
         view.openStories();
         if (isRaceActive()) {
             view.showTransmissionButton();
         }
+    }
+
+    @Override
+    public void onRestart(@NonNull MainScreenContract.View view) {
+        this.view = view;
     }
 
     private boolean isRaceActive() {

--- a/app/src/main/java/com/github/fo2rist/mclaren/ui/feedscreen/FeedPresenter.java
+++ b/app/src/main/java/com/github/fo2rist/mclaren/ui/feedscreen/FeedPresenter.java
@@ -1,5 +1,7 @@
 package com.github.fo2rist.mclaren.ui.feedscreen;
 
+import android.support.annotation.NonNull;
+
 import com.github.fo2rist.mclaren.analytics.Events;
 import com.github.fo2rist.mclaren.analytics.EventsLogger;
 import com.github.fo2rist.mclaren.models.FeedItem;
@@ -29,7 +31,7 @@ public class FeedPresenter implements FeedContract.Presenter {
     }
 
     @Override
-    public void onStart(FeedContract.View view) {
+    public void onStart(@NonNull FeedContract.View view) {
         this.view = view;
         this.repositoryPubSub.subscribe(this);
 

--- a/app/src/test/java/com/github/fo2rist/mclaren/ui/MainPresenterTest.java
+++ b/app/src/test/java/com/github/fo2rist/mclaren/ui/MainPresenterTest.java
@@ -16,6 +16,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 @RunWith(JUnit4.class)
@@ -46,6 +47,21 @@ public class MainPresenterTest {
         presenter.onStart(mockView);
 
         verify(mockView).openStories();
+    }
+
+    @Test
+    public void test_onRestart_onlySetView() {
+        reset(mockView);
+        reset(mockEventsLogger);
+        reset(mockCalendarRepository);
+
+        presenter.onRestart(mockView);
+
+        verifyNoMoreInteractions(mockView);
+        verifyNoMoreInteractions(mockEventsLogger);
+        verifyNoMoreInteractions(mockCalendarRepository);
+        //and make sure view is set so should not crash
+        presenter.onCarClicked(); // just call any methods that calls view
     }
 
     @Test


### PR DESCRIPTION
Main activity object can be destroyed in that case presenter will be recreated and re-bound to view but should not perform the initialization since Android will do that automatically, no re-binding will lead to NPE