### PR TITLE
Add Coveralls reports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,3 +45,4 @@ script:
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)
+  - ./gradlew coveralls

--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,10 @@ buildscript {
     }
 }
 
+plugins {
+    id "com.github.kt3k.coveralls" version "2.8.2"
+}
+
 allprojects {
     repositories {
         google()

--- a/jacoco.gradle
+++ b/jacoco.gradle
@@ -8,12 +8,14 @@ tasks.withType(Test) {
     jacoco.includeNoLocationClasses = true
 }
 
+final SOURCE_DIRS = "$project.projectDir/src/main/java"
+
 task jacocoTestDebugUnitTestReport(type: JacocoReport, dependsOn: ['testDebugUnitTest']) {
     group = "Code Coverage"
     description = "Generate coverage report for all unit test, analogue of createDebugCoverageReport"
 
     def coverageSourceDirs = [
-            "$project.projectDir/src/main/java"
+            SOURCE_DIRS
     ]
 
     def fileFilter = [
@@ -45,4 +47,9 @@ task jacocoTestDebugUnitTestReport(type: JacocoReport, dependsOn: ['testDebugUni
         xml.enabled = true
         html.enabled = true
     }
+}
+
+coveralls {
+    jacocoReportPath "$buildDir/reports/jacoco/jacocoTestDebugUnitTestReport/jacocoTestDebugUnitTestReport.xml"
+    sourceDirs = [SOURCE_DIRS]
 }


### PR DESCRIPTION
Add coveralls reports uploading plugin to gradle and add step to upload report to travis config
coveralls.io is yet another code coverage tracking service

- [x] tests added / no feature changes
- [x] build check passed
- [x] code self reviewed
