### PR TITLE
Set JVM limit for circle.ci to 1024Mb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,8 +9,8 @@ jobs:
     docker:
       - image: circleci/android:api-28-alpha
     environment:
-      JVM_OPTS: -Xmx1536m
-      _JAVA_OPTIONS: "-Xmx1536m"
+      JVM_OPTS: -Xmx1024m
+      _JAVA_OPTIONS: "-Xmx1024m"
     steps:
       - checkout
       - restore_cache:


### PR DESCRIPTION
Circle still fails from time to time even with the 1.5Gb limit

- [x] tests added / no feature changes
- [x] build check passed
- [x] code self reviewed
