### PR TITLE
Configure drivers list remotely

### DIFF
--- a/app/src/androidTest/java/com/github/fo2rist/mclaren/tests/DriversRepositoryIntegrationTest.java
+++ b/app/src/androidTest/java/com/github/fo2rist/mclaren/tests/DriversRepositoryIntegrationTest.java
@@ -1,42 +1,32 @@
 package com.github.fo2rist.mclaren.tests;
 
 import com.github.fo2rist.mclaren.repository.DriversRepositoryImpl;
+import com.github.fo2rist.mclaren.ui.models.Driver;
 import com.github.fo2rist.mclaren.ui.models.DriverId;
 import com.github.fo2rist.mclaren.ui.models.DriverProperty;
-import com.github.fo2rist.mclaren.ui.models.Driver;
 import com.github.fo2rist.mclaren.web.FirebaseRemoteConfigService;
-import java.util.Arrays;
-import java.util.List;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.JUnit4;
 
 import static junit.framework.Assert.assertFalse;
 import static junit.framework.Assert.assertNotNull;
-import static org.junit.runners.Parameterized.Parameters;
 
 /**
  * Test default values in driver repo for real app.
  */
-@RunWith(Parameterized.class)
+@RunWith(JUnit4.class)
 public class DriversRepositoryIntegrationTest {
-
-    @Parameters(name = "Driver: {0}")
-    public static List<DriverId> data() {
-        return Arrays.asList(DriverId.values());
-    }
-
-    @Parameter
-    public DriverId driverParam;
 
     private DriversRepositoryImpl driversRepository = new DriversRepositoryImpl(new FirebaseRemoteConfigService());
 
     @Test
     public void testAllMandatoryFieldsPresent() {
-        Driver driver = driversRepository.getDriver(driverParam);
+        for (DriverId driverId: driversRepository.getDriversList()) {
+            Driver driver = driversRepository.getDriver(driverId);
 
-        assertMandatoryFieldsPresent(driver);
+            assertMandatoryFieldsPresent(driver);
+        }
     }
 
     private void assertMandatoryFieldsPresent(Driver driver) {

--- a/app/src/main/java/com/github/fo2rist/mclaren/dagger/MainActivityModule.java
+++ b/app/src/main/java/com/github/fo2rist/mclaren/dagger/MainActivityModule.java
@@ -5,6 +5,7 @@ import com.github.fo2rist.mclaren.ui.MainActivity;
 import com.github.fo2rist.mclaren.ui.MainPresenter;
 import com.github.fo2rist.mclaren.ui.circuitsscreen.CircuitsFragment;
 import com.github.fo2rist.mclaren.ui.driversscreen.DriverSubFragment;
+import com.github.fo2rist.mclaren.ui.driversscreen.DriversFragment;
 import com.github.fo2rist.mclaren.ui.feedscreen.McLarenFeedFragment;
 import com.github.fo2rist.mclaren.ui.feedscreen.StoriesFeedFragment;
 import dagger.Binds;
@@ -24,6 +25,10 @@ abstract class MainActivityModule {
     @Scopes.PerFragment
     @ContributesAndroidInjector
     abstract CircuitsFragment circuitsFragmentInjector();
+
+    @Scopes.PerFragment
+    @ContributesAndroidInjector
+    abstract DriversFragment driversFragmentInjector();
 
     @Scopes.PerFragment
     @ContributesAndroidInjector

--- a/app/src/main/java/com/github/fo2rist/mclaren/repository/DriversRepository.kt
+++ b/app/src/main/java/com/github/fo2rist/mclaren/repository/DriversRepository.kt
@@ -1,6 +1,5 @@
 package com.github.fo2rist.mclaren.repository
 
-import android.support.annotation.VisibleForTesting
 import com.github.fo2rist.mclaren.ui.models.Driver
 import com.github.fo2rist.mclaren.ui.models.DriverId
 import com.github.fo2rist.mclaren.ui.models.DriverProperty
@@ -15,34 +14,47 @@ import javax.inject.Inject
 interface DriversRepository {
 
     /**
-     * Get driver info by ID.
-     * @throws IllegalArgumentException if the driver is not present.
+     * Get list of supported drivers in priority order.
      */
-    fun getDriver(driver: DriverId): Driver
+    val driversList: List<DriverId>
+
+    /**
+     * Get driver info by ID.
+     * @throws IllegalArgumentException if the driver is not present in [driversList].
+     */
+    fun getDriver(driverId: DriverId): Driver
 }
+
+private typealias DriverPropertiesConfigModel = Map<DriverProperty, String>
+private typealias DriversConfigModel = Map<DriverId, DriverPropertiesConfigModel>
 
 internal class DriversRepositoryImpl @Inject constructor(
     private val remoteConfigService: RemoteConfigService
 ) : DriversRepository {
 
-    @VisibleForTesting
-    val drivers: Map<DriverId, Driver> by lazy { loadDrivers() }
+    val drivers: List<Driver> by lazy { loadDrivers() }
 
-    private fun loadDrivers(): Map<DriverId, Driver> {
+    private fun loadDrivers(): List<Driver> {
         val driversModelTypeToken = object : TypeToken<DriversConfigModel>() {}
+        val driversListTypeToken = object : TypeToken<List<DriverId>>() {}
 
-        return parseJson(remoteConfigService.drivers, driversModelTypeToken)?.let {
-            it.mapValues { (id, properties) ->
-                Driver(id, properties)
-            }
-        } ?: emptyMap()
+        val driversInfoMap = parseJson(remoteConfigService.drivers, driversModelTypeToken)
+                ?.mapValues { (id, properties) ->
+                    Driver(id, properties)
+                } ?: emptyMap()
+        val driversOrderList = parseJson(remoteConfigService.driversOrderList, driversListTypeToken)
+                ?: emptyList()
+
+        return driversOrderList.mapNotNull {
+            driversInfoMap[it]
+        }
     }
 
-    override fun getDriver(driver: DriverId): Driver {
-        return drivers[driver]
-                ?: throw IllegalArgumentException("Unknown driver: $driver") //TODO maybe use empty model instead
+    override val driversList: List<DriverId>
+        get() = drivers.map { it.id }
+
+    override fun getDriver(driverId: DriverId): Driver {
+        return drivers.find { it.id == driverId }
+                ?: throw IllegalArgumentException("Unknown driver: $driverId")
     }
 }
-
-private typealias DriverPropertiesConfigModel = Map<DriverProperty, String>
-private typealias DriversConfigModel = Map<DriverId, DriverPropertiesConfigModel>

--- a/app/src/main/java/com/github/fo2rist/mclaren/ui/driversscreen/DriverSubFragment.java
+++ b/app/src/main/java/com/github/fo2rist/mclaren/ui/driversscreen/DriverSubFragment.java
@@ -165,12 +165,12 @@ public class DriverSubFragment extends Fragment implements View.OnClickListener 
 
     @NonNull
     private Uri makePortraitResUri(Driver driverModel) {
-        return ResourcesUtils.getDriverPortraitResUri(driverModel.getId());
+        return ResourcesUtils.getDriverPortraitResUri(driverModel.getFilesystemId());
     }
 
     @DrawableRes
     private int makeHelmetImageRes(Driver driverModel) {
-        return ResourcesUtils.getHelmetResId(getResources(), driverModel.getId());
+        return ResourcesUtils.getHelmetResId(getResources(), driverModel.getFilesystemId());
     }
 
     @Override

--- a/app/src/main/java/com/github/fo2rist/mclaren/ui/driversscreen/DriversFragment.java
+++ b/app/src/main/java/com/github/fo2rist/mclaren/ui/driversscreen/DriversFragment.java
@@ -1,5 +1,6 @@
 package com.github.fo2rist.mclaren.ui.driversscreen;
 
+import android.content.Context;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.v4.app.Fragment;
@@ -9,27 +10,34 @@ import android.view.View;
 import android.view.ViewGroup;
 
 import com.github.fo2rist.mclaren.R;
+import com.github.fo2rist.mclaren.repository.DriversRepository;
+import dagger.android.support.AndroidSupportInjection;
+import javax.inject.Inject;
 
 /**
  * Shows Team Drivers.
  * Two main drivers with info and summary page for others.
  */
 public class DriversFragment extends Fragment {
+    @Inject
+    DriversRepository driversRepository;
 
     public static DriversFragment newInstance() {
         return new DriversFragment();
     }
 
     @Override
-    public void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
+    public void onAttach(Context context) {
+        AndroidSupportInjection.inject(this);
+        super.onAttach(context);
     }
 
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View rootView = inflater.inflate(R.layout.fragment_drivers, container, false);
 
-        DriversPagerAdapter driversAdapter = new DriversPagerAdapter(getFragmentManager());
+        DriversPagerAdapter driversAdapter = new DriversPagerAdapter(
+                getFragmentManager(), driversRepository.getDriversList());
         ViewPager viewPager = rootView.findViewById(R.id.drivers_pager);
         viewPager.setAdapter(driversAdapter);
 

--- a/app/src/main/java/com/github/fo2rist/mclaren/ui/driversscreen/DriversPagerAdapter.java
+++ b/app/src/main/java/com/github/fo2rist/mclaren/ui/driversscreen/DriversPagerAdapter.java
@@ -5,35 +5,32 @@ import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentStatePagerAdapter;
 
 import com.github.fo2rist.mclaren.ui.models.DriverId;
-
-import static com.github.fo2rist.mclaren.ui.models.DriverId.CAMARA;
-import static com.github.fo2rist.mclaren.ui.models.DriverId.NORRIS;
-import static com.github.fo2rist.mclaren.ui.models.DriverId.SAINZ;
-import static com.github.fo2rist.mclaren.ui.models.DriverId.TURVEY;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Represent "tabs" on drivers page.
  */
 public class DriversPagerAdapter extends FragmentStatePagerAdapter {
-    private DriverId[] driverIds = new DriverId[]{SAINZ, NORRIS, TURVEY, CAMARA};
 
-    private DriverSubFragment[] pages = new DriverSubFragment[driverIds.length];
+    private ArrayList<DriverSubFragment> pages = new ArrayList<>();
 
-    public DriversPagerAdapter(FragmentManager fm) {
+    DriversPagerAdapter(FragmentManager fm, List<DriverId> driversList) {
         super(fm);
-        for (int i = 0; i < driverIds.length; i++) {
-            pages[i] = DriverSubFragment.newInstance(driverIds[i]);
+
+        for (DriverId driver: driversList) {
+            pages.add(DriverSubFragment.newInstance(driver));
         }
     }
 
     @Override
     public Fragment getItem(int position) {
-        return pages[position];
+        return pages.get(position);
     }
 
     @Override
     public int getCount() {
-        return pages.length;
+        return pages.size();
     }
 
 }

--- a/app/src/main/java/com/github/fo2rist/mclaren/ui/models/Driver.kt
+++ b/app/src/main/java/com/github/fo2rist/mclaren/ui/models/Driver.kt
@@ -3,30 +3,38 @@ package com.github.fo2rist.mclaren.ui.models
 /**
  * IDs of all known drivers.
  */
-enum class DriverId constructor(var id: String) {
+enum class DriverId constructor(
+    /**
+     * Unique string identifier associated with [DriverId].
+     * Used as filesystem name to store external resources.
+     */
+    var filesystemId: String
+) {
     ALONSO("alonso"),
     BUTTON("button"),
     CAMARA("camara"),
     NORRIS("norris"),
     SAINZ("sainz"),
     TURVEY("turvey"),
-    //removed resources
+
+    //region removed resources
     //the IDs can not be removed now, before the remote config that mentions these drivers is removed
     //and the app updated to the new version and the app updated so no user have the app with one of these drivers
     DEVRIES("devries"),
     MATSUSHITA("matsushita"),
     VANBUREN("vanburen"),
     VANDOORNE("vandoorne"),
+    //endregion
 }
 
 /**
  * Driver info for UI layer.
  */
 data class Driver(
-    private val id: DriverId,
+    val id: DriverId,
     private val properties: Map<DriverProperty, String>
 ) {
     operator fun get(property: DriverProperty) = properties[property]
 
-    fun getId(): String = id.id
+    fun getFilesystemId(): String = id.filesystemId
 }

--- a/app/src/main/java/com/github/fo2rist/mclaren/web/RemoteConfigService.kt
+++ b/app/src/main/java/com/github/fo2rist/mclaren/web/RemoteConfigService.kt
@@ -31,6 +31,11 @@ interface RemoteConfigService {
      * Drivers info JSON.
      */
     val drivers: String
+
+    /**
+     * Drivers display order list JSON.
+     */
+    val driversOrderList: String
 }
 
 /**
@@ -74,9 +79,13 @@ class FirebaseRemoteConfigService @Inject constructor() : RemoteConfigService {
     override val drivers: String
         get() = firebaseConfig.getString(DRIVERS)
 
+    override val driversOrderList: String
+        get() = firebaseConfig.getString(DRIVERS_ORDER_LIST)
+
     private companion object ConfigKeys {
         const val RACE_CALENDAR = "calendar"
         const val CIRCUITS = "circuits"
         const val DRIVERS = "drivers"
+        const val DRIVERS_ORDER_LIST = "drivers_order_list"
     }
 }

--- a/app/src/main/res/xml/app_config_defautls.xml
+++ b/app/src/main/res/xml/app_config_defautls.xml
@@ -534,4 +534,14 @@
             }
         </value>
     </entry>
+    <entry>
+        <key>drivers_order_list</key>
+        <value>
+            [
+                "SAINZ",
+                "NORRIS",
+                "TURVEY"
+            ]
+        </value>
+    </entry>
 </defaultsMap>

--- a/app/src/test/java/com/github/fo2rist/mclaren/testdata/FakeRemoteConfigService.kt
+++ b/app/src/test/java/com/github/fo2rist/mclaren/testdata/FakeRemoteConfigService.kt
@@ -6,7 +6,8 @@ import com.github.fo2rist.mclaren.web.RemoteConfigService
 class FakeRemoteConfigService internal constructor(
     override val calendar: String = "",
     override val circuits: String = "",
-    override val drivers: String = ""
+    override val drivers: String = "",
+    override val driversOrderList: String = ""
 ) : RemoteConfigService {
     override fun fetchConfig() {}
 }

--- a/app/src/test/java/com/github/fo2rist/mclaren/web/FirebaseRemoteConfigServiceTest.kt
+++ b/app/src/test/java/com/github/fo2rist/mclaren/web/FirebaseRemoteConfigServiceTest.kt
@@ -1,6 +1,8 @@
 package com.github.fo2rist.mclaren.web
 
 import com.google.firebase.FirebaseApp
+import org.json.JSONArray
+import org.json.JSONObject
 import org.junit.Assert.assertNotEquals
 import org.junit.Before
 import org.junit.Test
@@ -14,11 +16,17 @@ class FirebaseRemoteConfigServiceTest {
     @Before
     fun setUp() {
         // in tests Firebase is not initialized by default, so have to do that manually
+        // this will load default config XML supplied with the app
         FirebaseApp.initializeApp(RuntimeEnvironment.application)
     }
 
     @Test
-    fun `test initial config is not empty`() {
-        assertNotEquals(0, FirebaseRemoteConfigService().calendar.length)
+    fun `default config is not empty valid JSON`() {
+        val firebaseRemoteConfigService = FirebaseRemoteConfigService()
+
+        assertNotEquals(0, JSONArray(firebaseRemoteConfigService.calendar).length())
+        assertNotEquals(0, JSONArray(firebaseRemoteConfigService.circuits).length())
+        assertNotEquals(0, JSONArray(firebaseRemoteConfigService.driversOrderList).length())
+        assertNotEquals(0, JSONObject(firebaseRemoteConfigService.drivers).length())
     }
 }


### PR DESCRIPTION
Store ordered drivers list to display in remote config instead of hard-coding
Filter out drivers without info and drivers not present in the list

- [x] tests added / no feature changes
- [x] code self reviewed