### PR TITLE
Replace CodeQL auto-build step with gradle invocation

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -34,21 +34,8 @@ jobs:
       # with:
       #   languages: go, javascript, csharp, python, cpp, java
 
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
-
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 https://git.io/JvXDl
-
-    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
-    #    and modify them (or add more) to build your code if your project
-    #    uses a compiled language
-
-    #- run: |
-    #   make bootstrap
-    #   make release
+    - name: Build app
+      run: ./gradlew assembleDebug
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v1

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,4 +1,4 @@
-name: Android Pull Request Check
+name: PR Checks
 on: [push]
 
 env:
@@ -11,6 +11,7 @@ env:
 
 jobs:
   unitTest:
+    name: Unit test
     runs-on: ubuntu-latest
 
     steps:
@@ -25,6 +26,7 @@ jobs:
       uses: asadmansr/android-test-report-action@v1.2.0
 
   uiTest:
+    name: UI test local
     runs-on: macos-latest
     steps:
     - name: Checkout
@@ -37,6 +39,7 @@ jobs:
         script: ./gradlew connectedCheck
 
   cloudTest:
+    name: UI test on GCloud
     runs-on: ubuntu-latest
     steps:
     - name: Checkout


### PR DESCRIPTION
GitHub's autobuild doesn't work with Android, so need to build the app
to let CodeQL analyze Java bytecode

- [x] tests added / no feature changes
- [x] code self reviewed
