### PR TITLE
Exclude transitive dependencies of firebase analytics on ads library

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -116,7 +116,11 @@ dependencies {
     // firebase cloud config, crashlytics & analytics
     implementation 'com.google.firebase:firebase-config:19.2.0'
     implementation 'com.google.firebase:firebase-crashlytics:18.0.1'
-    implementation 'com.google.firebase:firebase-analytics:19.0.0'
+    implementation ('com.google.firebase:firebase-analytics:19.0.0') {
+        exclude module: "play-services-ads-identifier"
+        exclude module: "play-services-measurement"
+        exclude module: "play-services-measurement-sdk"
+    }
 
     //twitter client
     implementation "org.twitter4j:twitter4j-core:4.0.7"


### PR DESCRIPTION
This will prevent AdMob from falsely appearing as the library used by this app in analysis

- [x] tests added / no feature changes
- [x] code self reviewed
